### PR TITLE
Fix Indexing Errors when Applying Mutations

### DIFF
--- a/TODO
+++ b/TODO
@@ -3,3 +3,4 @@
  * merge Mono-/Multi-MolecularIntegrators, use map of (SNRs + Models) -> Template
  * template-ify Evaluator, Template for ModelConfig, get rid of unique_ptr-ing, EvaluatorFactory
  * SparsePoa isn't actually sparse, makeAlignmentColumn isn't using the provided beginRow/endRow
+ * Add more random tests of assumed invariants (e.g. mutating each position of a homopolymer should be identical)

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -165,13 +165,8 @@ void Template::Reset()
 
 void Template::ApplyMutation(const Mutation& mut)
 {
-    if (!InRange(mut.Start(), mut.End())) {
-        // update the start_ and end_ mappings
-        /* Note: A deletetion prior to the range spanned by this template
-           still affects the start/end */
-        AbstractTemplate::ApplyMutation(mut);
-        return;
-    }
+    // update mappings even if the mutation isn't in range
+    if (!InRange(mut.Start(), mut.End())) return AbstractTemplate::ApplyMutation(mut);
 
     const size_t i = mut.Start() - start_;
 

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -165,7 +165,13 @@ void Template::Reset()
 
 void Template::ApplyMutation(const Mutation& mut)
 {
-    if (!InRange(mut.Start(), mut.End())) return;
+    if (!InRange(mut.Start(), mut.End())) {
+        // update the start_ and end_ mappings
+        /* Note: A deletetion prior to the range spanned by this template
+           still affects the start/end */
+        AbstractTemplate::ApplyMutation(mut);
+        return;
+    }
 
     const size_t i = mut.Start() - start_;
 


### PR DESCRIPTION
Scenario: Imagine you have a read that spans from positions 5 to 20 on
the template.  You apply a mutation that deletes position 3.  Although
this mutation was not in the range mapped by the read, it does change
the coordinates, as the read now maps from 4 to 19.

Previously, we did not account for this, and if a mutation did not
overlap with the interval spanned by a read it would not update the
coordinates when that mutation was applied.  This could cause some
reads to be indexed +/- the true template.  As a result, they would score completely
different mutations than others and sub-optimal consensus
results occurred (errors).

Code review: 
@nlhepler @bnbowman 