### PR TITLE
Math fix for Variance < 0

### DIFF
--- a/src/Integrator.cpp
+++ b/src/Integrator.cpp
@@ -35,6 +35,7 @@ AddReadResult AbstractIntegrator::AddRead(std::unique_ptr<AbstractTemplate>&& tp
     try {
         eval.reset(new Evaluator(std::move(tpl), read, cfg_.ScoreDiff));
         const double zScore = eval->ZScore();
+        assert(std::isfinite(zScore));
         if (!std::isnan(cfg_.MinZScore) && (!std::isfinite(zScore) || zScore < cfg_.MinZScore)) {
             eval.reset(nullptr);
             result = AddReadResult::POOR_ZSCORE;


### PR DESCRIPTION
We were violating Jensen's inequality because (A + B) ^2 \neq A^2 + B^2
but we were calculating it this way when determining the second moment
which led to a negative variance estimate.  This change does two things:

* When calculating the second moment it does (A + B)^2 instead of A^2 +
B^2
* When calculating the expected log likelihood of a match, it also
includes the log of (1 - eps) and eps. (this change is unrelated to the
first)

More details on the calculation can be found in commit f4684f67 for the
VariantCallingReports repo.  This change was ported from the Original
pbccs codebase.