### PR TITLE
Make Enum Size Explicit

### DIFF
--- a/include/pacbio/consensus/Integrator.h
+++ b/include/pacbio/consensus/Integrator.h
@@ -27,7 +27,15 @@ enum struct AddReadResult : uint8_t
     SUCCESS,
     ALPHA_BETA_MISMATCH,
     POOR_ZSCORE,
-    OTHER
+    OTHER,
+    /* 
+     This enum is used in other places to
+     both size an array and index into it.  So
+     users can know the number of elements needed in 
+     an array that could count valus of this enum, this
+     should always be the last value in the enum.
+     */
+    SIZE
 };
 
 inline std::ostream& operator<<(std::ostream& os, AddReadResult result)


### PR DESCRIPTION
In other libraries we assume AddReadResult::OTHER is the last element
and use it to create arrays that can be indexed with any value of
AddReadResult.  However, this is a convention that is not checked by
the compiler and is entirely dependent on some programmer remembering
how this enum used in a different library.  While not a compiler guard,
explicitly creating an end SIZE element and commenting it should guard
against future users placing another value after OTHER.