### PR TITLE
don't update mappings when mut doesn't apply, match prob and asserts

### DIFF
--- a/include/pacbio/consensus/Evaluator.h
+++ b/include/pacbio/consensus/Evaluator.h
@@ -11,14 +11,22 @@
 namespace PacBio {
 namespace Consensus {
 
+enum struct EvaluatorState : uint8_t
+{
+    VALID,
+    ALPHA_BETA_MISMATCH,
+    POOR_ZSCORE,
+    NULL_TEMPLATE
+};
+
 // forward declaration
 class EvaluatorImpl;
 
 class Evaluator
 {
 public:
-    Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr,
-              double scoreDiff = 12.5);
+    Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr, double minZScore,
+              double scoreDiff);
 
     // move constructors
     Evaluator(Evaluator&&);
@@ -26,8 +34,9 @@ public:
     ~Evaluator();
 
     size_t Length() const;
-    char operator[](size_t i) const;
-    operator std::string() const;
+    StrandEnum Strand() const;
+
+    operator bool() const;
 
     double LL(const Mutation& mut);
     double LL() const;
@@ -39,8 +48,15 @@ public:
     bool ApplyMutation(const Mutation& mut);
     bool ApplyMutations(std::vector<Mutation>* muts);
 
+    EvaluatorState Status() const;
+
+private:
+    void CheckInvariants();
+
+public:
 private:
     std::unique_ptr<EvaluatorImpl> impl_;
+    EvaluatorState state_;
 };
 
 }  // namespace Consensus

--- a/include/pacbio/consensus/Evaluator.h
+++ b/include/pacbio/consensus/Evaluator.h
@@ -36,8 +36,8 @@ public:
 
     double ZScore() const;
 
-    void ApplyMutation(const Mutation& mut);
-    void ApplyMutations(std::vector<Mutation>* muts);
+    bool ApplyMutation(const Mutation& mut);
+    bool ApplyMutations(std::vector<Mutation>* muts);
 
 private:
     std::unique_ptr<EvaluatorImpl> impl_;

--- a/include/pacbio/consensus/Evaluator.h
+++ b/include/pacbio/consensus/Evaluator.h
@@ -16,7 +16,8 @@ enum struct EvaluatorState : uint8_t
     VALID,
     ALPHA_BETA_MISMATCH,
     POOR_ZSCORE,
-    NULL_TEMPLATE
+    NULL_TEMPLATE,
+    DISABLED
 };
 
 // forward declaration
@@ -25,6 +26,7 @@ class EvaluatorImpl;
 class Evaluator
 {
 public:
+    Evaluator(EvaluatorState);
     Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr, double minZScore,
               double scoreDiff);
 
@@ -49,11 +51,11 @@ public:
     bool ApplyMutations(std::vector<Mutation>* muts);
 
     EvaluatorState Status() const;
+    void Release();
 
 private:
     void CheckInvariants();
 
-public:
 private:
     std::unique_ptr<EvaluatorImpl> impl_;
     EvaluatorState state_;

--- a/include/pacbio/consensus/Integrator.h
+++ b/include/pacbio/consensus/Integrator.h
@@ -19,7 +19,7 @@ struct IntegratorConfig
     double MinZScore;
     double ScoreDiff;
 
-    IntegratorConfig(double minZScore = -5.0, double scoreDiff = 12.5);
+    IntegratorConfig(double minZScore = -3.5, double scoreDiff = 12.5);
 };
 
 enum struct AddReadResult : uint8_t
@@ -66,12 +66,6 @@ public:
     virtual void ApplyMutations(std::vector<Mutation>* muts) = 0;
 
 protected:
-    struct ReadState : std::unique_ptr<Evaluator>
-    {
-        ReadState(std::unique_ptr<Evaluator>&& ptr, StrandEnum strand);
-        StrandEnum Strand;
-    };
-
     Mutation ReverseComplement(const Mutation& mut) const;
 
     AbstractIntegrator(const IntegratorConfig& cfg);
@@ -82,7 +76,7 @@ protected:
     AddReadResult AddRead(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& read);
 
     IntegratorConfig cfg_;
-    std::vector<ReadState> evals_;
+    std::vector<Evaluator> evals_;
 };
 
 class MonoMolecularIntegrator : public AbstractIntegrator

--- a/include/pacbio/consensus/Mutation.h
+++ b/include/pacbio/consensus/Mutation.h
@@ -55,6 +55,9 @@ public:
         else if (lhs.End() == rhs.End() && lhs.Start() < rhs.Start())
             return true;
 
+        else if (lhs.End() == rhs.End() && lhs.Start() == rhs.Start() && lhs.IsDeletion())
+            return true;
+
         return false;
     }
 

--- a/include/pacbio/consensus/Read.h
+++ b/include/pacbio/consensus/Read.h
@@ -27,7 +27,8 @@ struct Read
 enum struct StrandEnum : uint8_t
 {
     FORWARD,
-    REVERSE
+    REVERSE,
+    UNMAPPED
 };
 
 struct MappedRead : public Read

--- a/include/pacbio/consensus/Template.h
+++ b/include/pacbio/consensus/Template.h
@@ -29,8 +29,8 @@ public:
     virtual void Reset() = 0;
 
     // actually apply mutations
-    virtual void ApplyMutation(const Mutation& mut);
-    virtual void ApplyMutations(std::vector<Mutation>* muts);
+    virtual bool ApplyMutation(const Mutation& mut);
+    virtual bool ApplyMutations(std::vector<Mutation>* muts);
 
     // access model configuration
     virtual double BaseEmissionPr(MoveType move, char from, char to) const = 0;
@@ -70,7 +70,7 @@ public:
     boost::optional<Mutation> Mutate(const Mutation& mut);
     void Reset();
 
-    void ApplyMutation(const Mutation& mut);
+    bool ApplyMutation(const Mutation& mut);
 
     inline double BaseEmissionPr(MoveType move, char from, char to) const;
     inline double CovEmissionPr(MoveType move, uint8_t cov, char from, char to) const;
@@ -99,7 +99,7 @@ public:
     inline bool IsMutated() const;
     inline boost::optional<Mutation> Mutate(const Mutation&);
     inline void Reset() {}
-    void ApplyMutation(const Mutation& mut);
+    bool ApplyMutation(const Mutation& mut);
 
     inline double BaseEmissionPr(MoveType move, char from, char to) const;
     inline double CovEmissionPr(MoveType move, uint8_t cov, char from, char to) const;

--- a/include/pacbio/consensus/Version.h.in
+++ b/include/pacbio/consensus/Version.h.in
@@ -14,6 +14,9 @@ struct Version
 
     static std::string ToString()
     { return CC2_VERSION; }
+
+    static std::string GitSha1()
+    { return CC2_GIT_SHA1; }
 };
 
 }  // namespace Consensus

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -98,7 +98,7 @@ EvaluatorState Evaluator::Status() const { return state_; }
 void Evaluator::CheckInvariants()
 {
     if (!impl_) return;
-    if (impl_->recursor_.tpl_->Length() == 0) state_ = EvaluatorState::NULL_TEMPLATE;
+    if (impl_->recursor_.tpl_->Length() < 2) state_ = EvaluatorState::NULL_TEMPLATE;
     if (state_ != EvaluatorState::VALID) impl_.reset(nullptr);
 }
 

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -15,6 +15,13 @@ constexpr size_t EXTEND_BUFFER_COLUMNS = 8;
 
 }  // anonymous namespace
 
+Evaluator::Evaluator(const EvaluatorState state)
+    : impl_{nullptr}, state_{state}
+{
+    if (state_ == EvaluatorState::VALID)
+        throw std::invalid_argument("cannot initialize a dummy Evaluator with VALID state");
+}
+
 Evaluator::Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr,
                      const double minZScore, const double scoreDiff)
     : impl_{nullptr}, state_{EvaluatorState::VALID}
@@ -95,6 +102,8 @@ bool Evaluator::ApplyMutations(std::vector<Mutation>* muts)
 }
 
 EvaluatorState Evaluator::Status() const { return state_; }
+void Evaluator::Release() { state_ = EvaluatorState::DISABLED; impl_.reset(nullptr); }
+
 void Evaluator::CheckInvariants()
 {
     if (!impl_) return;

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -24,7 +24,7 @@ double Evaluator::LL(const Mutation& mut) { return impl_->LL(mut); }
 double Evaluator::LL() const { return impl_->LL(); }
 std::pair<double, double> Evaluator::NormalParameters() const { return impl_->NormalParameters(); }
 double Evaluator::ZScore() const { return impl_->ZScore(); }
-void Evaluator::ApplyMutation(const Mutation& mut) { impl_->ApplyMutation(mut); }
-void Evaluator::ApplyMutations(std::vector<Mutation>* muts) { impl_->ApplyMutations(muts); }
+bool Evaluator::ApplyMutation(const Mutation& mut) { return impl_->ApplyMutation(mut); }
+bool Evaluator::ApplyMutations(std::vector<Mutation>* muts) { return impl_->ApplyMutations(muts); }
 }  // namespace Consensus
 }  // namespace PacBio

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -3,8 +3,6 @@
 
 #include <boost/optional.hpp>
 
-#include <pacbio/consensus/Evaluator.h>
-
 #include "EvaluatorImpl.h"
 
 namespace PacBio {
@@ -58,7 +56,7 @@ EvaluatorImpl::EvaluatorImpl(std::unique_ptr<AbstractTemplate>&& tpl, const Mapp
     , beta_(mr.Length() + 1, recursor_.tpl_->Length() + 1)
     , extendBuffer_(mr.Length() + 1, EXTEND_BUFFER_COLUMNS)
 {
-    if (recursor_.tpl_->Length() > 0) recursor_.FillAlphaBeta(alpha_, beta_);
+    recursor_.FillAlphaBeta(alpha_, beta_);
     if (!std::isfinite(LL())) throw AlphaBetaMismatch();
 }
 
@@ -146,7 +144,6 @@ double EvaluatorImpl::LL(const Mutation& mut_)
 
 double EvaluatorImpl::LL() const
 {
-    if (recursor_.tpl_->Length() == 0) return 0.0;
     return std::log(beta_(0, 0)) + beta_.GetLogProdScales() +
            recursor_.tpl_->UndoCounterWeights(recursor_.read_.Length());
 }
@@ -165,7 +162,6 @@ double EvaluatorImpl::ZScore() const
 
 inline void EvaluatorImpl::Recalculate()
 {
-    if (recursor_.tpl_->Length() == 0) return;
     size_t I = recursor_.read_.Length() + 1;
     size_t J = recursor_.tpl_->Length() + 1;
     alpha_.Reset(I, J);

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -69,9 +69,6 @@ double EvaluatorImpl::LL(const Mutation& mut_)
     // apply the virtual mutation
     if (!mut) return LL();
 
-    // if the length of the new template is zero, we don't contribute anything
-    if (recursor_.tpl_->Length() == 0) return 0.0;
-
     size_t betaLinkCol = 1 + mut->End();
     size_t absoluteLinkColumn = 1 + mut->End() + mut->LengthDiff();
 

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -177,16 +177,22 @@ inline void EvaluatorImpl::Recalculate()
     recursor_.FillAlphaBeta(alpha_, beta_);
 }
 
-void EvaluatorImpl::ApplyMutation(const Mutation& mut)
+bool EvaluatorImpl::ApplyMutation(const Mutation& mut)
 {
-    recursor_.tpl_->ApplyMutation(mut);
-    Recalculate();
+    if (recursor_.tpl_->ApplyMutation(mut)) {
+        Recalculate();
+        return true;
+    }
+    return false;
 }
 
-void EvaluatorImpl::ApplyMutations(std::vector<Mutation>* muts)
+bool EvaluatorImpl::ApplyMutations(std::vector<Mutation>* muts)
 {
-    recursor_.tpl_->ApplyMutations(muts);
-    Recalculate();
+    if (recursor_.tpl_->ApplyMutations(muts)) {
+        Recalculate();
+        return true;
+    }
+    return false;
 }
 
 /*

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -62,9 +62,16 @@ EvaluatorImpl::EvaluatorImpl(std::unique_ptr<AbstractTemplate>&& tpl, const Mapp
 
 double EvaluatorImpl::LL(const Mutation& mut_)
 {
+    // apply the virtual mutation
     boost::optional<Mutation> mut(recursor_.tpl_->Mutate(mut_));
 
-    // apply the virtual mutation
+    // if the resulting template is 0, simulate NULL_TEMPLATE (removal)
+    if (recursor_.tpl_->Length() == 0) {
+        recursor_.tpl_->Reset();
+        return 0.0;
+    }
+
+    // if the mutation didn't hit this read, just return the ll as-is
     if (!mut) return LL();
 
     size_t betaLinkCol = 1 + mut->End();

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -58,7 +58,7 @@ EvaluatorImpl::EvaluatorImpl(std::unique_ptr<AbstractTemplate>&& tpl, const Mapp
     , beta_(mr.Length() + 1, recursor_.tpl_->Length() + 1)
     , extendBuffer_(mr.Length() + 1, EXTEND_BUFFER_COLUMNS)
 {
-    recursor_.FillAlphaBeta(alpha_, beta_);
+    if (recursor_.tpl_->Length() > 0) recursor_.FillAlphaBeta(alpha_, beta_);
     if (!std::isfinite(LL())) throw AlphaBetaMismatch();
 }
 
@@ -68,6 +68,9 @@ double EvaluatorImpl::LL(const Mutation& mut_)
 
     // apply the virtual mutation
     if (!mut) return LL();
+
+    // if the length of the new template is zero, we don't contribute anything
+    if (recursor_.tpl_->Length() == 0) return 0.0;
 
     size_t betaLinkCol = 1 + mut->End();
     size_t absoluteLinkColumn = 1 + mut->End() + mut->LengthDiff();
@@ -146,6 +149,7 @@ double EvaluatorImpl::LL(const Mutation& mut_)
 
 double EvaluatorImpl::LL() const
 {
+    if (recursor_.tpl_->Length() == 0) return 0.0;
     return std::log(beta_(0, 0)) + beta_.GetLogProdScales() +
            recursor_.tpl_->UndoCounterWeights(recursor_.read_.Length());
 }
@@ -164,6 +168,7 @@ double EvaluatorImpl::ZScore() const
 
 inline void EvaluatorImpl::Recalculate()
 {
+    if (recursor_.tpl_->Length() == 0) return;
     size_t I = recursor_.read_.Length() + 1;
     size_t J = recursor_.tpl_->Length() + 1;
     alpha_.Reset(I, J);

--- a/src/EvaluatorImpl.cpp
+++ b/src/EvaluatorImpl.cpp
@@ -57,7 +57,6 @@ EvaluatorImpl::EvaluatorImpl(std::unique_ptr<AbstractTemplate>&& tpl, const Mapp
     , extendBuffer_(mr.Length() + 1, EXTEND_BUFFER_COLUMNS, ScaledMatrix::FORWARD)
 {
     recursor_.FillAlphaBeta(alpha_, beta_);
-    if (!std::isfinite(LL())) throw AlphaBetaMismatch();
 }
 
 double EvaluatorImpl::LL(const Mutation& mut_)

--- a/src/EvaluatorImpl.h
+++ b/src/EvaluatorImpl.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include <pacbio/consensus/Evaluator.h>
 #include <pacbio/consensus/Read.h>
 #include <pacbio/consensus/Template.h>
 
@@ -39,6 +40,8 @@ private:
     ScaledMatrix alpha_;
     ScaledMatrix beta_;
     ScaledMatrix extendBuffer_;
+
+    friend class Evaluator;
 };
 
 }  // namespace Consensus

--- a/src/EvaluatorImpl.h
+++ b/src/EvaluatorImpl.h
@@ -27,8 +27,8 @@ public:
 
     double ZScore() const;
 
-    void ApplyMutation(const Mutation& mut);
-    void ApplyMutations(std::vector<Mutation>* muts);
+    bool ApplyMutation(const Mutation& mut);
+    bool ApplyMutations(std::vector<Mutation>* muts);
 
 private:
     void Recalculate();

--- a/src/Integrator.cpp
+++ b/src/Integrator.cpp
@@ -35,7 +35,7 @@ AddReadResult AbstractIntegrator::AddRead(std::unique_ptr<AbstractTemplate>&& tp
     try {
         eval.reset(new Evaluator(std::move(tpl), read, cfg_.ScoreDiff));
         const double zScore = eval->ZScore();
-        assert(std::isfinite(zScore));
+        // assert(std::isfinite(zScore));
         if (!std::isnan(cfg_.MinZScore) && (!std::isfinite(zScore) || zScore < cfg_.MinZScore)) {
             eval.reset(nullptr);
             result = AddReadResult::POOR_ZSCORE;

--- a/src/Integrator.cpp
+++ b/src/Integrator.cpp
@@ -30,8 +30,10 @@ AbstractIntegrator::~AbstractIntegrator() {}
 AddReadResult AbstractIntegrator::AddRead(std::unique_ptr<AbstractTemplate>&& tpl,
                                           const MappedRead& read)
 {
-    if (read.TemplateEnd <= read.TemplateStart)
-        throw std::invalid_argument("invalid read mapping, template end <= start");
+    if (read.TemplateEnd <= read.TemplateStart || read.TemplateEnd - read.TemplateStart < 2)
+        throw std::invalid_argument("template span < 2!");
+
+    if (read.Length() < 2) throw std::invalid_argument("read span < 2!");
 
     evals_.emplace_back(Evaluator(std::move(tpl), read, cfg_.MinZScore, cfg_.ScoreDiff));
 

--- a/src/Recursor.cpp
+++ b/src/Recursor.cpp
@@ -414,7 +414,7 @@ void Recursor::ExtendAlpha(const M& alpha, size_t beginColumn, M& ext, size_t nu
         // TODO: ERROR! Fix this. Temporary hack is to merge the columns in
         // front and behind.
         // Still totally broken.
-        if (j < tpl_->Length()) {
+        if (j < alpha.Columns()) {
             std::tie(beginRow, endRow) = alpha.UsedRowRange(j);
             size_t pBegin, pEnd, nBegin, nEnd;
             if (j > 0) {
@@ -422,7 +422,7 @@ void Recursor::ExtendAlpha(const M& alpha, size_t beginColumn, M& ext, size_t nu
                 beginRow = std::min(beginRow, pBegin);
                 endRow = std::max(endRow, pEnd);
             }
-            if ((j + 1) < tpl_->Length()) {
+            if ((j + 1) < alpha.Columns()) {
                 std::tie(nBegin, nEnd) = alpha.UsedRowRange(j + 1);
                 beginRow = std::min(beginRow, nBegin);
                 endRow = std::max(endRow, nEnd);
@@ -551,12 +551,12 @@ void Recursor::ExtendBeta(const M& beta, size_t lastColumn, M& ext, int lengthDi
         } else {
             std::tie(beginRow, endRow) = beta.UsedRowRange(j);
             int pBegin, pEnd, nBegin, nEnd;
-            if ((j - 1) >= 0) {
+            if (j > 0) {
                 std::tie(pBegin, pEnd) = beta.UsedRowRange(j - 1);
                 beginRow = std::min(beginRow, pBegin);
                 endRow = std::max(endRow, pEnd);
             }
-            if ((j + 1) < tpl_->Length()) {
+            if ((j + 1) < beta.Columns()) {
                 std::tie(nBegin, nEnd) = beta.UsedRowRange(j + 1);
                 beginRow = std::min(beginRow, nBegin);
                 endRow = std::max(endRow, nEnd);

--- a/src/Recursor.cpp
+++ b/src/Recursor.cpp
@@ -637,10 +637,11 @@ size_t Recursor::FillAlphaBeta(M& a, M& b) const throw(AlphaBetaMismatch)
         flipflops += 3;
     }
 
+    const double unweight = tpl_->UndoCounterWeights(read_.Length());
     double alphaV, betaV;
     while (flipflops <= MAX_FLIP_FLOPS) {
-        alphaV = std::log(a(I, J)) + a.GetLogProdScales();
-        betaV = std::log(b(0, 0)) + b.GetLogProdScales();
+        alphaV = std::log(a(I, J)) + a.GetLogProdScales() + unweight;
+        betaV = std::log(b(0, 0)) + b.GetLogProdScales() + unweight;
 
         if (std::abs(1.0 - alphaV / betaV) <= ALPHA_BETA_MISMATCH_TOLERANCE) break;
 

--- a/src/Recursor.cpp
+++ b/src/Recursor.cpp
@@ -187,7 +187,7 @@ void Recursor::FillAlpha(const M& guide, M& alpha) const
      * information */
     {
         auto currTplBase = (*tpl_)[J - 1].Base;
-        auto prevTplBase = (*tpl_)[J - 2].Base;
+        assert(J < 2 || prevTplBase == (*tpl_)[J - 2].Base);
         // end in the homopolymer state for now.
         auto likelihood =
             alpha(I - 1, J - 1) *

--- a/src/Recursor.cpp
+++ b/src/Recursor.cpp
@@ -618,8 +618,7 @@ Recursor::Recursor(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr
 
 size_t Recursor::FillAlphaBeta(M& a, M& b) const throw(AlphaBetaMismatch)
 {
-    if (tpl_->Length() == 0)
-        throw std::runtime_error("template length is 0, invalid state!");
+    if (tpl_->Length() == 0) throw std::runtime_error("template length is 0, invalid state!");
 
     FillAlpha(M::Null(), a);
     FillBeta(a, b);

--- a/src/Recursor.cpp
+++ b/src/Recursor.cpp
@@ -652,7 +652,8 @@ size_t Recursor::FillAlphaBeta(M& a, M& b) const throw(AlphaBetaMismatch)
         ++flipflops;
     }
 
-    if (std::abs(1.0 - alphaV / betaV) > ALPHA_BETA_MISMATCH_TOLERANCE) throw AlphaBetaMismatch();
+    if (std::abs(1.0 - alphaV / betaV) > ALPHA_BETA_MISMATCH_TOLERANCE || !std::isfinite(betaV))
+        throw AlphaBetaMismatch();
 
     return flipflops;
 }

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -238,11 +238,12 @@ void Template::Reset()
 
 bool Template::ApplyMutation(const Mutation& mut)
 {
-    if (Length() == 0 && mut.LengthDiff() < 1) return false;
-
     bool mutApplied = false;
 
-    if (InRange(mut.Start(), mut.End())) {
+    if (Length() == 0 && mut.LengthDiff() < 1) goto finish;
+    if (!InRange(mut.Start(), mut.End())) goto finish;
+
+    {
         const size_t i = mut.Start() - start_;
 
         if (mut.Type == MutationType::INSERTION) {
@@ -276,6 +277,7 @@ bool Template::ApplyMutation(const Mutation& mut)
         mutApplied = true;
     }
 
+finish:
     // update the start_ and end_ mappings
     AbstractTemplate::ApplyMutation(mut);
 

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -24,7 +24,7 @@ void AbstractTemplate::ApplyMutation(const Mutation& mut)
 
     // if the end of the mutation is before the start of our mapping,
     //   update the mapping
-    if (!pinStart_ && mut.End() < start_) start_ += mut.LengthDiff();
+    if (!pinStart_ && mut.End() <= start_) start_ += mut.LengthDiff();
 
     assert(start_ < end_);
 }
@@ -186,14 +186,14 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
         if (mutStart_ < tpl_.size())
             mutTpl_[1] = cfg_->Populate({mut.Base, tpl_[mutStart_].Base})[0];
         else
-            mutTpl_[1] = TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0};
+            mutTpl_[1] = TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0};
     } else if (mut.Type == MutationType::SUBSTITUTION) {
         if (mutStart_ > 0) mutTpl_[0] = cfg_->Populate({tpl_[mutStart_ - 1].Base, mut.Base})[0];
 
         if (mutStart_ + 1 < tpl_.size())
             mutTpl_[1] = cfg_->Populate({mut.Base, tpl_[mutStart_ + 1].Base})[0];
         else
-            mutTpl_[1] = TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0};
+            mutTpl_[1] = TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0};
     } else if (mut.Type == MutationType::DELETION) {
         // if there's a predecessor, fill it
         if (mutStart_ > 0) {
@@ -201,7 +201,7 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
                 mutTpl_[0] =
                     cfg_->Populate({tpl_[mutStart_ - 1].Base, tpl_[mutStart_ + 1].Base})[0];
             else
-                mutTpl_[0] = TemplatePosition{tpl_[mutStart_ - 1].Base, 0.0, 0.0, 0.0, 0.0};
+                mutTpl_[0] = TemplatePosition{tpl_[mutStart_ - 1].Base, 1.0, 0.0, 0.0, 0.0};
         }
 
         // if there's a successor, the params for the mutant position
@@ -215,7 +215,7 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
     mutOff_ = mut.LengthDiff();
     mutated_ = true;
 
-    assert((*this)[Length() - 1].Match == 0.0 && (*this)[Length() - 1].Branch == 0.0 &&
+    assert((*this)[Length() - 1].Match == 1.0 && (*this)[Length() - 1].Branch == 0.0 &&
            (*this)[Length() - 1].Stick == 0.0 && (*this)[Length() - 1].Deletion == 0.0);
 
     return Mutation(mut.Type, mutStart_, mut.Base);
@@ -242,7 +242,7 @@ void Template::ApplyMutation(const Mutation& mut)
             if (i < tpl_.size())
                 tpl_.insert(tpl_.begin() + i, cfg_->Populate({mut.Base, tpl_[i].Base})[0]);
             else
-                tpl_.emplace_back(TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0});
+                tpl_.emplace_back(TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0});
         } else if (mut.Type == MutationType::SUBSTITUTION) {
             if (i > 0) tpl_[i - 1] = cfg_->Populate({tpl_[i - 1].Base, mut.Base})[0];
 
@@ -257,7 +257,7 @@ void Template::ApplyMutation(const Mutation& mut)
                 if (i < tpl_.size())
                     tpl_[i - 1] = cfg_->Populate({tpl_[i - 1].Base, tpl_[i].Base})[0];
                 else
-                    tpl_[i - 1] = TemplatePosition{tpl_[i - 1].Base, 0.0, 0.0, 0.0, 0.0};
+                    tpl_[i - 1] = TemplatePosition{tpl_[i - 1].Base, 1.0, 0.0, 0.0, 0.0};
             }
         } else
             throw std::invalid_argument(
@@ -269,7 +269,7 @@ void Template::ApplyMutation(const Mutation& mut)
     AbstractTemplate::ApplyMutation(mut);
 
     assert(tpl_.size() == end_ - start_);
-    assert((*this)[Length() - 1].Match == 0.0 && (*this)[Length() - 1].Branch == 0.0 &&
+    assert((*this)[Length() - 1].Match == 1.0 && (*this)[Length() - 1].Branch == 0.0 &&
            (*this)[Length() - 1].Stick == 0.0 && (*this)[Length() - 1].Deletion == 0.0);
 
     assert(!pinStart_ || start_ == 0);

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -188,13 +188,6 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
     mutStart_ = mut.Start() - start_;
     mutEnd_ = mut.End() - start_;
 
-    // TODO(lhepler): The following should never happen, but does.
-    //     find the root cause, fix it, and nuke this line
-    /*
-    if (mutStart_ > tpl_.size() || (mutStart_ == tpl_.size() && mut.Type == MutationType::DELETION))
-        return boost::none;
-    */
-
     if (mut.Type == MutationType::INSERTION) {
         if (mutStart_ > 0) mutTpl_[0] = cfg_->Populate({tpl_[mutStart_ - 1].Base, mut.Base})[0];
 
@@ -251,10 +244,6 @@ bool Template::ApplyMutation(const Mutation& mut)
 
     if (InRange(mut.Start(), mut.End())) {
         const size_t i = mut.Start() - start_;
-
-        // TODO(lhepler): The following should never happen, but does.
-        //     find the root cause, fix it, and nuke this line
-        // if (i > tpl_.size() || (i == tpl_.size() && mut.Type == MutationType::DELETION)) return;
 
         if (mut.Type == MutationType::INSERTION) {
             if (i > 0) tpl_[i - 1] = cfg_->Populate({tpl_[i - 1].Base, mut.Base})[0];

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -43,9 +43,10 @@ std::pair<double, double> AbstractTemplate::NormalParameters() const
     double mean = 0.0, var = 0.0;
     /* Brute forcing this for clarity of code as I don't think this is limiting.
      Should profiling show this is a problem, we can use the fact that there are only
-     8 possible dinucleotide contexts and so we can multiply instead of performing repeated addition.
+     8 possible dinucleotide contexts and so we can multiply instead of performing repeated
+     addition.
      e.g. A + B + A + A + B = 3 * A + 2 * B, so we could avoid the nested add step */
- 
+
     // Now sum up the mean and variance
     for (size_t i = 0; (i + 1) < Length(); ++i) {
         double m, v;
@@ -53,29 +54,28 @@ std::pair<double, double> AbstractTemplate::NormalParameters() const
         mean += m;
         /* Add the variance, note that the sites are independent so
            Var (A + B) = Var(A) + Var(B) as Cov(A,B) = 0 */
-        var += v; // Add the variance (note sites are indpe
+        var += v;  // Add the variance (note sites are indpe
     }
     return std::make_pair(mean, var);
 }
 
 size_t AbstractTemplate::TrueLength() const { return end_ - start_; }
-    
 /* See PBEP #4 for a write-up of this code and an explanation of the algorithm.
-     
+
      The R script below can be used to validate the moments are calculated correctly by
      comparing to a brute-force simulation
-     
+
      # Sample Parameters
      p_m  = 0.95583140484751283
      p_d  = 0.00097238955012494488
      p_b  = 0.029256323818866534
      p_s  = 0.013939881783495679
      eps  = 0.00505052456472967
-     
+
      # Expected Results
      mean  = -0.27568172991312162
      var = 1.019204780302317
-     
+
      pmE = p_m / (p_m + p_d)
      exitLL <- function() {
      if (runif(1) < pmE) {
@@ -88,7 +88,7 @@ size_t AbstractTemplate::TrueLength() const { return end_ - start_; }
      return(log(p_d))
      }
      }
-     
+
      insertLL <- function() {
      LL <- 0
      pbI = p_b / (p_b + p_s)
@@ -101,7 +101,7 @@ size_t AbstractTemplate::TrueLength() const { return end_ - start_; }
      }
      return(LL)
      }
-     
+
      getSamp <- function() {
      return(insertLL() + exitLL())
      }
@@ -111,38 +111,40 @@ size_t AbstractTemplate::TrueLength() const { return end_ - start_; }
 */
 std::pair<double, double> AbstractTemplate::SiteNormalParameters(const size_t i) const
 {
-    //TODO (ndelaney): This probably needs to be matched to the specific model being used.
+    // TODO (ndelaney): This probably needs to be matched to the specific model being used.
     // std::log(1.0/3);
     constexpr double lgThird = -1.0986122886681098;
     const auto params = (*this)[i];
     const double eps = 1.0 - BaseEmissionPr(MoveType::MATCH, params.Base, params.Base);
-    
-    const double p_m = params.Match,     l_m = std::log(p_m),  l2_m = l_m * l_m;
-    const double p_d = params.Deletion,  l_d = std::log(p_d),  l2_d = l_d * l_d;
-    const double p_b = params.Branch,    l_b = std::log(p_b),  l2_b = l_b * l_b;
-    const double p_s = params.Stick,     l_s = std::log(p_s),  l2_s = l_s * l_s;
-    
+
+    const double p_m = params.Match, l_m = std::log(p_m), l2_m = l_m * l_m;
+    const double p_d = params.Deletion, l_d = std::log(p_d), l2_d = l_d * l_d;
+    const double p_b = params.Branch, l_b = std::log(p_b), l2_b = l_b * l_b;
+    const double p_s = params.Stick, l_s = std::log(p_s), l2_s = l_s * l_s;
+
     const double lgeps = std::log(eps);
     const double lg1minusEps = std::log(1.0 - eps);
-    
+
     // First moment expectations (zero terms used for clarity)
-    const double E_M = (1.0 - eps) * lg1minusEps   + eps * (lgThird + lgeps);
+    const double E_M = (1.0 - eps) * lg1minusEps + eps * (lgThird + lgeps);
     const double E_D = 0.0;
     const double E_B = 0.0;
     const double E_S = lgThird;
-    
+
     // Calculate first moment
     const double E_MD = (l_m + E_M) * p_m / (p_m + p_d) + (l_d + E_D) * p_d / (p_m + p_d);
-    const double E_I  = (l_b + E_B) * p_b / (p_b + p_s) + (l_s + E_S) * p_s / (p_b + p_s);
+    const double E_I = (l_b + E_B) * p_b / (p_b + p_s) + (l_s + E_S) * p_s / (p_b + p_s);
     const double E_BS = E_I * (p_s + p_b) / (p_m + p_d);
     const double mean = E_MD + E_BS;
-    
+
     // Calculate second momment
     // Key expansion used repeatedly here: (A + B)^2 = A^2 + 2AB + B^2
-    const double E2_M = (1.0 - eps) * pow(lg1minusEps, 2.0)  + eps * pow(lgThird + lgeps, 2.0);
-    const double E2_MD = (l2_m + 2 * l_m * E_M + E2_M) * p_m / (p_m + p_d) + l2_d * p_d / (p_m + p_d);
+    const double E2_M = (1.0 - eps) * pow(lg1minusEps, 2.0) + eps * pow(lgThird + lgeps, 2.0);
+    const double E2_MD =
+        (l2_m + 2 * l_m * E_M + E2_M) * p_m / (p_m + p_d) + l2_d * p_d / (p_m + p_d);
     const double E2_S = pow(lgThird, 2.0);
-    const double E2_I = l2_b * p_b / (p_b + p_s) + (l2_s + 2 * E_S * l_s + E2_S ) * p_s / (p_b + p_s);
+    const double E2_I =
+        l2_b * p_b / (p_b + p_s) + (l2_s + 2 * E_S * l_s + E2_S) * p_s / (p_b + p_s);
     const double E2_BS = E2_I * (p_s + p_b) / (p_m + p_d);
     const double moment2 = E2_BS + 2 * E_BS * E_MD + E2_MD;
     const double var = moment2 - mean * mean;

--- a/src/matrix/ScaledMatrix.cpp
+++ b/src/matrix/ScaledMatrix.cpp
@@ -1,10 +1,17 @@
 
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+
 #include "ScaledMatrix.h"
 
 namespace PacBio {
 namespace Consensus {
 
-ScaledMatrix::ScaledMatrix(int rows, int cols) : SparseMatrix(rows, cols), logScalars_(cols, 0.0) {}
+ScaledMatrix::ScaledMatrix(int rows, int cols, Direction dir)
+    : SparseMatrix(rows, cols), logScalars_(cols, 0.0), dir_{dir}
+{
+}
 ScaledMatrix::ScaledMatrix(const ScaledMatrix& other)
     : SparseMatrix(other), logScalars_(other.logScalars_)
 {
@@ -14,6 +21,29 @@ void ScaledMatrix::Reset(size_t rows, size_t cols)
 {
     std::vector<double>(cols, 0.0).swap(logScalars_);
     SparseMatrix::Reset(rows, cols);
+}
+
+ScaledMatrix::Direction ScaledMatrix::SetDirection(const Direction dir)
+{
+    const Direction res = dir_;
+    dir_ = dir;
+    std::fill(logScalars_.begin(), logScalars_.end(), 0.0);
+    return res;
+}
+
+std::ostream& operator<<(std::ostream& os, const ScaledMatrix& mat)
+{
+    os << "MATRIX (" << mat.Rows() << ", " << mat.Columns() << ") BEGIN" << std::endl;
+    os << std::fixed << std::setprecision(4);
+    for (size_t i = 0; i < mat.Rows(); ++i) {
+        os << ' ';
+        for (size_t j = 0; j < mat.Columns(); ++j) {
+            os << ' ' << std::setw(9) << std::log(mat.Get(i, j)) + mat.GetLogScale(j);
+        }
+        os << std::endl;
+    }
+    os << "END" << std::endl;
+    return os;
 }
 
 }  // namespace Consensus

--- a/swig/ConsensusCore2.i.in
+++ b/swig/ConsensusCore2.i.in
@@ -69,6 +69,7 @@ namespace std
 %include "Mutation.i"
 %include "Polish.i"
 %include "Read.i"
+%include "Version.i"
 
 // after ModelConfig.i and Mutation.i
 // %include "Template.i"

--- a/swig/Version.i
+++ b/swig/Version.i
@@ -1,0 +1,6 @@
+
+%{
+#include <pacbio/consensus/Version.h>
+%}
+
+%include <pacbio/consensus/Version.h>

--- a/tests/TestTemplate.cpp
+++ b/tests/TestTemplate.cpp
@@ -273,7 +273,8 @@ TEST(TemplateTest, TestPinning)
         master.ApplyMutation(Mutation(MutationType::INSERTION, 0, 'A'));
         EXPECT_EQ(len, master.Length());
         EXPECT_EQ(tpl, ToString(master));
-        master.ApplyMutation(Mutation(MutationType::INSERTION, len, 'A'));
+        // the coords are now 1..6, so a new terminal mutation is at len+1
+        master.ApplyMutation(Mutation(MutationType::INSERTION, len + 1, 'A'));
         EXPECT_EQ(len + 1, master.Length());
         EXPECT_EQ(tpl + A, ToString(master));
     }

--- a/tests/TestTemplate.cpp
+++ b/tests/TestTemplate.cpp
@@ -304,4 +304,40 @@ TEST(TemplateTest, TestPinning)
     }
 }
 
+TEST(TemplateTest, NullTemplate)
+{
+    const string tpl = "ACGT";
+    const size_t len = tpl.length();
+    const Mutation mut(MutationType::DELETION, 0, '-');
+
+    Template master(tpl, ModelFactory::Create(mdl, snr), 0, len, true, true);
+    VirtualTemplate virt(master, 0, len, false, false);
+
+    EXPECT_EQ(len, master.Length());
+
+    for (size_t i = 1; i <= len; ++i) {
+        master.ApplyMutation(mut);
+        EXPECT_EQ(len - i, master.Length());
+        virt.ApplyMutation(mut);
+        EXPECT_EQ(len - i, virt.Length());
+    }
+
+    {
+        const string A(1, 'A');
+
+        auto mut_ = master.Mutate(mut);
+        EXPECT_FALSE(bool(mut_));
+        master.ApplyMutation(mut);
+
+        mut_ = master.Mutate(Mutation(MutationType::INSERTION, 0, 'A'));
+        ASSERT_TRUE(bool(mut_));
+        EXPECT_EQ(A, ToString(master));
+        master.Reset();
+        master.ApplyMutation(*mut_);
+        EXPECT_EQ(A, ToString(master));
+        virt.ApplyMutation(*mut_);
+        EXPECT_EQ(0, virt.Length());
+    }
+}
+
 }  // namespace anonymous


### PR DESCRIPTION
This fixes mutations at the end and the corresponding asserts, and a borked case where the mutation wasn't in InRange but we updated the mappings anyway (a pinStart corner-case)