### PR TITLE
Fix SIGSEGV

### DIFF
--- a/include/pacbio/consensus/Evaluator.h
+++ b/include/pacbio/consensus/Evaluator.h
@@ -24,8 +24,10 @@ public:
     Evaluator(Evaluator&&);
 
     ~Evaluator();
-
-    size_t Length() const;
+    /* Returns the length of the alignment on the template.
+     * In certain circumstances this can go to 0 and the read should be 
+     * removed. */
+    size_t TemplateSpan() const;
     char operator[](size_t i) const;
     operator std::string() const;
 
@@ -38,6 +40,7 @@ public:
 
     void ApplyMutation(const Mutation& mut);
     void ApplyMutations(std::vector<Mutation>* muts);
+    void Recalculate();
 
 private:
     std::unique_ptr<EvaluatorImpl> impl_;

--- a/include/pacbio/consensus/Integrator.h
+++ b/include/pacbio/consensus/Integrator.h
@@ -51,7 +51,10 @@ class AbstractIntegrator
 {
 public:
     virtual ~AbstractIntegrator();
-
+    /* This method removes any evaluators that no longer
+     * span any portion of the template.
+     */
+    virtual void RemoveInvalidAlignments();
     virtual size_t Length() const = 0;
     virtual char operator[](size_t i) const = 0;
     virtual operator std::string() const = 0;

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -20,11 +20,14 @@ Evaluator::Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& 
 
 Evaluator::Evaluator(Evaluator&& eval) : impl_{std::move(eval.impl_)} {}
 Evaluator::~Evaluator() {}
+
+size_t Evaluator::TemplateSpan() const {return impl_->TemplateSpan();}
 double Evaluator::LL(const Mutation& mut) { return impl_->LL(mut); }
 double Evaluator::LL() const { return impl_->LL(); }
 std::pair<double, double> Evaluator::NormalParameters() const { return impl_->NormalParameters(); }
 double Evaluator::ZScore() const { return impl_->ZScore(); }
 void Evaluator::ApplyMutation(const Mutation& mut) { impl_->ApplyMutation(mut); }
 void Evaluator::ApplyMutations(std::vector<Mutation>* muts) { impl_->ApplyMutations(muts); }
+void Evaluator::Recalculate() { impl_->Recalculate();}
 }  // namespace Consensus
 }  // namespace PacBio

--- a/src/EvaluatorImpl.h
+++ b/src/EvaluatorImpl.h
@@ -22,6 +22,9 @@ public:
 
     double LL(const Mutation& mut);
     double LL() const;
+    
+    
+    size_t TemplateSpan() const;
 
     std::pair<double, double> NormalParameters() const;
 
@@ -29,9 +32,11 @@ public:
 
     void ApplyMutation(const Mutation& mut);
     void ApplyMutations(std::vector<Mutation>* muts);
-
-private:
     void Recalculate();
+private:    
+    /* Used to check that any assumptions made by the likelihood calculator are
+     true.  Should be called whenever the template is created or mutated. */
+    void ValidateAssumptions();
 
 private:
     Recursor recursor_;

--- a/src/Integrator.cpp
+++ b/src/Integrator.cpp
@@ -202,6 +202,15 @@ void MonoMolecularIntegrator::ApplyMutation(const Mutation& fwdMut)
                 eval->ApplyMutation(revMut);
         }
     }
+    
+    // Now clean out anything that no longer aligns to the template
+    RemoveInvalidAlignments();
+    // And recalculate the likelihoods
+    for (auto& eval : evals_) {
+       if (eval) {
+               eval->Recalculate();
+            }
+    }   
 
     assert(fwdTpl_.Length() == revTpl_.Length());
 
@@ -314,6 +323,15 @@ void MultiMolecularIntegrator::ApplyMutation(const Mutation& fwdMut)
                 eval->ApplyMutation(fwdMut);
             else
                 eval->ApplyMutation(revMut);
+        }
+    }
+    
+    // Now clean out anything that no longer aligns to the template
+    RemoveInvalidAlignments();
+    // And recalculate the likelihoods
+    for (auto& eval : evals_) {
+        if (eval) {
+            eval->Recalculate();
         }
     }
 

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -26,7 +26,7 @@ void AbstractTemplate::ApplyMutation(const Mutation& mut)
     //   update the mapping
     if (!pinStart_ && mut.End() < start_) start_ += mut.LengthDiff();
 
-    assert(start_ < end_);
+    assert(start_ <= end_);
 }
 
 void AbstractTemplate::ApplyMutations(std::vector<Mutation>* const muts)
@@ -122,14 +122,14 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
         if (mutStart_ < tpl_.size())
             mutTpl_[1] = cfg_->Populate({mut.Base, tpl_[mutStart_].Base})[0];
         else
-            mutTpl_[1] = TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0};
+            mutTpl_[1] = TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0};
     } else if (mut.Type == MutationType::SUBSTITUTION) {
         if (mutStart_ > 0) mutTpl_[0] = cfg_->Populate({tpl_[mutStart_ - 1].Base, mut.Base})[0];
 
         if (mutStart_ + 1 < tpl_.size())
             mutTpl_[1] = cfg_->Populate({mut.Base, tpl_[mutStart_ + 1].Base})[0];
         else
-            mutTpl_[1] = TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0};
+            mutTpl_[1] = TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0};
     } else if (mut.Type == MutationType::DELETION) {
         // if there's a predecessor, fill it
         if (mutStart_ > 0) {
@@ -137,7 +137,7 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
                 mutTpl_[0] =
                     cfg_->Populate({tpl_[mutStart_ - 1].Base, tpl_[mutStart_ + 1].Base})[0];
             else
-                mutTpl_[0] = TemplatePosition{tpl_[mutStart_ - 1].Base, 0.0, 0.0, 0.0, 0.0};
+                mutTpl_[0] = TemplatePosition{tpl_[mutStart_ - 1].Base, 1.0, 0.0, 0.0, 0.0};
         }
 
         // if there's a successor, the params for the mutant position
@@ -151,7 +151,7 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
     mutOff_ = mut.LengthDiff();
     mutated_ = true;
 
-    assert((*this)[Length() - 1].Match == 0.0 && (*this)[Length() - 1].Branch == 0.0 &&
+    assert((*this)[Length() - 1].Match == 1.0 && (*this)[Length() - 1].Branch == 0.0 &&
            (*this)[Length() - 1].Stick == 0.0 && (*this)[Length() - 1].Deletion == 0.0);
 
     return Mutation(mut.Type, mutStart_, mut.Base);
@@ -178,7 +178,7 @@ void Template::ApplyMutation(const Mutation& mut)
             if (i < tpl_.size())
                 tpl_.insert(tpl_.begin() + i, cfg_->Populate({mut.Base, tpl_[i].Base})[0]);
             else
-                tpl_.emplace_back(TemplatePosition{mut.Base, 0.0, 0.0, 0.0, 0.0});
+                tpl_.emplace_back(TemplatePosition{mut.Base, 1.0, 0.0, 0.0, 0.0});
         } else if (mut.Type == MutationType::SUBSTITUTION) {
             if (i > 0) tpl_[i - 1] = cfg_->Populate({tpl_[i - 1].Base, mut.Base})[0];
 
@@ -193,7 +193,7 @@ void Template::ApplyMutation(const Mutation& mut)
                 if (i < tpl_.size())
                     tpl_[i - 1] = cfg_->Populate({tpl_[i - 1].Base, tpl_[i].Base})[0];
                 else
-                    tpl_[i - 1] = TemplatePosition{tpl_[i - 1].Base, 0.0, 0.0, 0.0, 0.0};
+                    tpl_[i - 1] = TemplatePosition{tpl_[i - 1].Base, 1.0, 0.0, 0.0, 0.0};
             }
         } else
             throw std::invalid_argument(
@@ -205,7 +205,7 @@ void Template::ApplyMutation(const Mutation& mut)
     AbstractTemplate::ApplyMutation(mut);
 
     assert(tpl_.size() == end_ - start_);
-    assert((*this)[Length() - 1].Match == 0.0 && (*this)[Length() - 1].Branch == 0.0 &&
+    assert((*this)[Length() - 1].Match == 1.0 && (*this)[Length() - 1].Branch == 0.0 &&
            (*this)[Length() - 1].Stick == 0.0 && (*this)[Length() - 1].Deletion == 0.0);
 
     assert(!pinStart_ || start_ == 0);


### PR DESCRIPTION
If a template is mutated so that a subread is no longer aligned to any
part of it, we wind up in big trouble.  In particular, the code tries
to index a matrix at column 0 - 1 = Max(size_t), which quite often
leads to errors.  This problem is pretty deep in the code, and can
really only happen when there is a very noisy subread that does not
belong with the others.

This error can strike when:

	* A template is initially created
	* A mutation is scored
	* A mutation is applied (which triggers a refill of the matrices)

How to handle it?  We originally threw a SmallTemplateException in
these cases, and given that this is a very rare case, it seemed like
the cleanest way to handle this.  However, to properly handle this, I
split up the code so that instead of mutations being applied and then
immediately recalculating the score, a mutation is applied, empty
alignments are removed, and then the score is recalculated.  This logic
should avoid this case, but exceptions are peppered throughout the code
to verify that we never have a template span of size 0 and robustify
against SIGSEGV chances.

This change revealed a number of other issues, in particular:

	* Scoring insertions at the end of templates could lead to a different SIGSEGV, I have altered that as well.
	* The convention that the intial basepair have a match probability of 1 was not enforced throughout, leading to errors.  I have fixed this.

Additionally, the logic for picking the range of rows to use in
ExtendAlpha was far too complicated and led to errors.  Rather than
micro-guess each column, I use the same range for all columns we are
extending over.