### PR TITLE
Remove disabled Z-score

### DIFF
--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -33,10 +33,6 @@ Evaluator::Evaluator(std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& 
 
         const double zScore = impl_->ZScore();
 
-        // the zscore filter is disabled under the following conditions
-        if ((mr.Model.find("S/P1-C1") != std::string::npos) ||
-            (mr.Model.find("S/P2-C2/prospective-compatible") != std::string::npos))
-            goto end;
         if (minZScore <= -100.0) goto end;
         if (std::isnan(minZScore)) goto end;
 


### PR DESCRIPTION
Shown is a quick comparison below of a run of 2k lambda with and without a minimum Z-score filter of -7.  There is a lot that affects this but it's basically a straight yield versus accuracy trade-off.  Since QUAL=93 corresponds to a QV just over 30 I am going to look into that more.

![image](https://cloud.githubusercontent.com/assets/1330626/15450497/ccd4c2fc-1f51-11e6-8fbc-5b49a7acc338.png)

![image](https://cloud.githubusercontent.com/assets/1330626/15450513/184ce8d6-1f52-11e6-9bf2-e2510c716018.png)

![image](https://cloud.githubusercontent.com/assets/1330626/15450540/b7316094-1f52-11e6-9660-7d687d3a9236.png)
