### PR TITLE
Try out simple "insertion burst" filter

### DIFF
--- a/include/pacbio/consensus/Template.h
+++ b/include/pacbio/consensus/Template.h
@@ -159,7 +159,7 @@ public:
                              size_t numExtColumns = 2) const = 0;
     virtual void ExtendBeta(const M& beta, size_t endColumn, M& ext, int lengthDiff = 0) const = 0;
     virtual double UndoCounterWeights(size_t nEmissions) const = 0;
-
+    virtual std::vector<double> GetInsertionCounts(M& alpha, M& beta) const = 0;
 public:
     std::unique_ptr<AbstractTemplate> tpl_;
     MappedRead read_;

--- a/src/EvaluatorImpl.h
+++ b/src/EvaluatorImpl.h
@@ -36,8 +36,10 @@ public:
 
 private:
     void Recalculate();
+    void CreateInsertionFilter();
 
 private:
+    int FilteredBases;
     std::unique_ptr<AbstractRecursor>
         recursor_;  // TODO: does this need to be a pointer?  is it always non-null?
                     // are we making it a UP just so we can do a fwd decl and still have
@@ -45,6 +47,7 @@ private:
     ScaledMatrix alpha_;
     ScaledMatrix beta_;
     ScaledMatrix extendBuffer_;
+    std::vector<bool> mask_;
 
     friend class Evaluator;
 };


### PR DESCRIPTION
This commit is a collection of quick edits that enable read localized
editing to avoid regions with many insertions affecting consensus.  The
code works by pseudocounting insertions to generate masks that locally
filter noisy regions.  The implementation is only to quickly test the
idea, as this is not production code.