### PR TITLE
No pollution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_git_sha1(CC2_GIT_SHA1)
 
 configure_file(
     ${PacBioConsensus_IncludeDir}/pacbio/consensus/Version.h.in
-    ${PacBioConsensus_IncludeDir}/pacbio/consensus/Version.h
+    ${CMAKE_BINARY_DIR}/generated/pacbio/consensus/Version.h
 )
 
 file(GLOB_RECURSE PacBioConsensus_CPP "${PacBioConsensus_SourceDir}/*.cpp")
@@ -48,7 +48,10 @@ if(HAS_NO_UNUSED_VARIABLE)
 endif(HAS_NO_UNUSED_VARIABLE)
 
 # includes
-include_directories(. ${PacBioConsensus_IncludeDir})
+include_directories(
+    ${PacBioConsensus_IncludeDir}
+    ${CMAKE_BINARY_DIR}/generated
+)
 include_directories(SYSTEM
     ${Boost_INCLUDE_DIRS}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # pthread
 find_package(Threads)
 
@@ -9,21 +8,7 @@ set(GMOCK_IncludeDir ${GMOCK_RootDir})
 file(GLOB           GMOCK_CC    "${GMOCK_RootDir}/*.cc")
 file(GLOB_RECURSE   GMOCK_H     "${GMOCK_RootDir}/*.h")
 
-# output directory
-file(MAKE_DIRECTORY  ${PacBioConsensus_TestsDir}/bin)
-
-include_directories(
-    ${PacBioConsensus_IncludeDir}
-)
-
-# Generate paths for test data
-#configure_file(
-#    ${PacBioConsensus_TestsDir}/TestData.h.in
-#    ${PacBioConsensus_TestsDir}/TestData.h
-#)
-
 include_directories(SYSTEM
-    ${Boost_INCLUDE_DIRS}
     ${GMOCK_IncludeDir}
 )
 
@@ -34,9 +19,7 @@ add_executable(test_pbconsensus EXCLUDE_FROM_ALL
     ${GMOCK_CC}
     ${GMOCK_H}
 )
-set_target_properties(test_pbconsensus PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PacBioConsensus_TestsDir}/bin
-)
+
 target_link_libraries(test_pbconsensus
     ${PBCONSENSUS_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
Do not generate config file into include/, rather build/generated/. Do not export test executable outside build directory. Remove double includes.