### PR TITLE
Comment Cyclic Behavior Guard

### DIFF
--- a/src/Polish.cpp
+++ b/src/Polish.cpp
@@ -220,7 +220,14 @@ std::tuple<bool, size_t, size_t> Polish(AbstractIntegrator* ai, const PolishConf
         const size_t newTpl = hashFn(ApplyMutations(*ai, &muts));
 
         if (history.find(newTpl) != history.end()) {
-            // cyclic behavior detected! apply just the single best mutation
+            /* Cyclic behavior guard - Dave A. found some edge cases where the
+             template was mutating back to an earlier version. This is a bad
+             and should be rare.  He found that by applying the single best
+             mutation you could avoid the loop. (That is if adding Muts X + Y
+             made removing muts X + Y beneficial, then you can break that
+             inifinite loop by just applying X or Y, as presumably this removes
+             the interaction between them that leads to the cycling behavior.
+             This step is just a heuristic work around that was found. */            
             ai->ApplyMutation(muts.front());
             oldTpl = hashFn(*ai);
             ++nApplied;


### PR DESCRIPTION
This step confused me so I wanted to add comments (it wasn’t clear if
the best scoring or simply any mutation would work).  This seems to be
a nice work around that was added, and just wanted to make it clear
that one should not spend too much time deriving the provenance of the
exact steps taken.

@dalexander @nlhepler