### PR TITLE
refactor z-score supporting functions

### DIFF
--- a/include/pacbio/consensus/ModelConfig.h
+++ b/include/pacbio/consensus/ModelConfig.h
@@ -78,6 +78,12 @@ enum struct MoveType : uint8_t
     DELETION = 3  // never used for covariate
 };
 
+enum struct MomentType : uint8_t
+{
+    FIRST = 0,
+    SECOND = 1
+};
+
 class ModelConfig
 {
 public:
@@ -85,10 +91,8 @@ public:
     virtual std::unique_ptr<AbstractRecursor> CreateRecursor(
         std::unique_ptr<AbstractTemplate>&& tpl, const MappedRead& mr, double scoreDiff) const = 0;
     virtual std::vector<TemplatePosition> Populate(const std::string& tpl) const = 0;
-    virtual double ExpectedLogLikelihoodForMatchEmission(uint8_t prev, uint8_t curr, bool secondMoment) const = 0;
-    virtual double ExpectedLogLikelihoodForStickEmission(uint8_t prev, uint8_t curr, bool secondMoment) const = 0;
-    virtual double ExpectedLogLikelihoodForBranchEmission(uint8_t prev, uint8_t curr, bool secondMoment) const = 0;
-    
+    virtual double ExpectedLLForEmission(MoveType move, uint8_t prev, uint8_t curr,
+                                         MomentType moment) const = 0;
 };
 
 }  // namespace Consensus

--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -172,17 +172,17 @@ std::pair<double, double> AbstractTemplate::SiteNormalParameters(const size_t i)
     // place (or really just move directly to using .Idx without bit shifting
     const uint8_t prev = (i == 0) ? 0 : (*this)[i - 1].Idx;  // default base : A
     const uint8_t curr = params.Idx;
-    
+
     const double p_m = params.Match, l_m = std::log(p_m), l2_m = l_m * l_m;
     const double p_d = params.Deletion, l_d = std::log(p_d), l2_d = l_d * l_d;
     const double p_b = params.Branch, l_b = std::log(p_b), l2_b = l_b * l_b;
     const double p_s = params.Stick, l_s = std::log(p_s), l2_s = l_s * l_s;
-    
+
     // First moment expectations (zero terms used for clarity)
-    const double E_M = ExpectedLogLikelihoodForMatchEmission(prev, curr, false);
+    const double E_M = ExpectedLLForEmission(MoveType::MATCH, prev, curr, MomentType::FIRST);
     const double E_D = 0.0;
-    const double E_B = ExpectedLogLikelihoodForBranchEmission(prev, curr, false);
-    const double E_S = ExpectedLogLikelihoodForStickEmission(prev, curr, false);
+    const double E_B = ExpectedLLForEmission(MoveType::BRANCH, prev, curr, MomentType::FIRST);
+    const double E_S = ExpectedLLForEmission(MoveType::STICK, prev, curr, MomentType::FIRST);
 
     // Calculate first moment
     const double E_MD = (l_m + E_M) * p_m / (p_m + p_d) + (l_d + E_D) * p_d / (p_m + p_d);
@@ -192,9 +192,9 @@ std::pair<double, double> AbstractTemplate::SiteNormalParameters(const size_t i)
 
     // Calculate second momment
     // Key expansion used repeatedly here: (A + B)^2 = A^2 + 2AB + B^2
-    const double E2_M = ExpectedLogLikelihoodForMatchEmission(prev, curr, true);
-    const double E2_S = ExpectedLogLikelihoodForStickEmission(prev, curr, true);
-    const double E2_B = ExpectedLogLikelihoodForBranchEmission(prev, curr, true);
+    const double E2_M = ExpectedLLForEmission(MoveType::MATCH, prev, curr, MomentType::SECOND);
+    const double E2_S = ExpectedLLForEmission(MoveType::STICK, prev, curr, MomentType::SECOND);
+    const double E2_B = ExpectedLLForEmission(MoveType::BRANCH, prev, curr, MomentType::SECOND);
     const double E2_MD =
         (l2_m + 2 * l_m * E_M + E2_M) * p_m / (p_m + p_d) + l2_d * p_d / (p_m + p_d);
     const double E2_I =


### PR DESCRIPTION
or, why have three functions when you can have one