### PR TITLE
Do not throw TemplateTooSmall in Mutate()

### DIFF
--- a/src/Template.cpp
+++ b/src/Template.cpp
@@ -291,8 +291,6 @@ boost::optional<Mutation> Template::Mutate(const Mutation& mut)
            ((*this)[Length() - 1].Match == 1.0 && (*this)[Length() - 1].Branch == 0.0 &&
             (*this)[Length() - 1].Stick == 0.0 && (*this)[Length() - 1].Deletion == 0.0));
 
-    if (Length() < 2) throw TemplateTooSmall();
-
     return Mutation(mut.Type, mutStart_, mut.Base);
 }
 


### PR DESCRIPTION
This caused failures in API endpoints that are not tested in cram tests.